### PR TITLE
Add margin to figures and render markup in includes

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -10,13 +10,14 @@
 	{% comment %} if dropshadow is false, remove the box-shadow inherited by <img> {% endcomment %}
     {% assign style = style | append: "box-shadow: none;" %}
 {% endif %}
-{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
-{% comment %}the whole include's output and markdownify it.{% endcomment %}
-{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
-{% capture includeresult %}
+{% comment %}
+We want to markdownify the caption, however the markdownify filter does not offer an "inline" mode
+(see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
+{% endcomment %}
+{% if include.caption %}
+	{% assign include.caption = include.caption | markdownify | remove: "<p>" | remove: "</p>" %}
+{% endif %}
 <figure>
   <img src="{{include.src}}" style="{{style}}">
-  {% if include.caption %}<figcaption>{{include.caption}}</figcaption>{% endif %}
+  {% if include.caption %}<figcaption>{{include.caption | markdownify | strip | }}</figcaption>{% endif %}
 </figure>
-{% endcapture %}
-{{ includeresult | markdownify }}

--- a/_includes/figure
+++ b/_includes/figure
@@ -12,5 +12,5 @@
 {% endif %}
 <figure>
   <img src="{{include.src}}" style="{{style}}">
-  {% if include.caption %}<figcaption>{{include.caption}}</figcaption>{% endif %}
+  {% if include.caption %}<figcaption>{{include.caption | markdownify}}</figcaption>{% endif %}
 </figure>

--- a/_includes/figure
+++ b/_includes/figure
@@ -12,5 +12,5 @@
 {% endif %}
 <figure>
   <img src="{{include.src}}" style="{{style}}">
-  {% if include.caption %}<figcaption>{{include.caption | markdownify}}</figcaption>{% endif %}
+  {% if include.caption %}<figcaption>{{include.caption | markdownify | strip}}</figcaption>{% endif %}
 </figure>

--- a/_includes/figure
+++ b/_includes/figure
@@ -14,10 +14,7 @@
 We want to markdownify the caption, however the markdownify filter does not offer an "inline" mode
 (see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
 {% endcomment %}
-{% if include.caption %}
-	{% assign include.caption = include.caption | markdownify | remove: "<p>" | remove: "</p>" %}
-{% endif %}
 <figure>
   <img src="{{include.src}}" style="{{style}}">
-  {% if include.caption %}<figcaption>{{include.caption | markdownify | strip | }}</figcaption>{% endif %}
+  {% if include.caption %}<figcaption>{{include.caption | markdownify | remove: "<p>" | remove: "</p>"}}</figcaption>{% endif %}
 </figure>

--- a/_includes/figure
+++ b/_includes/figure
@@ -10,7 +10,13 @@
 	{% comment %} if dropshadow is false, remove the box-shadow inherited by <img> {% endcomment %}
     {% assign style = style | append: "box-shadow: none;" %}
 {% endif %}
+{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
+{% comment %}the whole include's output and markdownify it.{% endcomment %}
+{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
+{% capture includeresult %}
 <figure>
   <img src="{{include.src}}" style="{{style}}">
-  {% if include.caption %}<figcaption>{{include.caption | markdownify | strip}}</figcaption>{% endif %}
+  {% if include.caption %}<figcaption>{{include.caption}}</figcaption>{% endif %}
 </figure>
+{% endcapture %}
+{{ includeresult | markdownify }}

--- a/_includes/info
+++ b/_includes/info
@@ -1,6 +1,6 @@
 <div class="info-popup">
     <p>
         <i class="fa fa-info-circle"></i>
-        <b>{{include.title | markdownify}}:</b> {{include.content | markdownify}}
+        <b>{{include.title | markdownify | strip}}:</b> {{include.content | markdownify | strip}}
     </p>
 </div>

--- a/_includes/info
+++ b/_includes/info
@@ -1,6 +1,6 @@
 <div class="info-popup">
     <p>
         <i class="fa fa-info-circle"></i>
-        <b>{{include.title}}:</b> {{include.content}}
+        <b>{{include.title | markdownify}}:</b> {{include.content | markdownify}}
     </p>
 </div>

--- a/_includes/info
+++ b/_includes/info
@@ -1,12 +1,12 @@
-{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
-{% comment %}the whole include's output and markdownify it.{% endcomment %}
-{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
-{% capture includeresult %}
+{% comment %}
+We want to markdownify the title/content, however the markdownify filter does not offer an "inline" mode
+(see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
+{% endcomment %}
+{% assign include.title = include.title | markdownify | remove: "<p>" | remove: "</p>" %}
+{% assign include.content = include.content | markdownify | remove: "<p>" | remove: "</p>" %}
 <div class="info-popup">
     <p>
         <i class="fa fa-info-circle"></i>
         <b>{{include.title}}:</b> {{include.content}}
     </p>
 </div>
-{% endcapture %}
-{{ includeresult | markdownify }}

--- a/_includes/info
+++ b/_includes/info
@@ -1,6 +1,12 @@
+{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
+{% comment %}the whole include's output and markdownify it.{% endcomment %}
+{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
+{% capture includeresult %}
 <div class="info-popup">
     <p>
         <i class="fa fa-info-circle"></i>
-        <b>{{include.title | markdownify | strip}}:</b> {{include.content | markdownify | strip}}
+        <b>{{include.title}}:</b> {{include.content}}
     </p>
 </div>
+{% endcapture %}
+{{ includeresult | markdownify }}

--- a/_includes/info
+++ b/_includes/info
@@ -2,11 +2,9 @@
 We want to markdownify the title/content, however the markdownify filter does not offer an "inline" mode
 (see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
 {% endcomment %}
-{% assign include.title = include.title | markdownify | remove: "<p>" | remove: "</p>" %}
-{% assign include.content = include.content | markdownify | remove: "<p>" | remove: "</p>" %}
 <div class="info-popup">
     <p>
         <i class="fa fa-info-circle"></i>
-        <b>{{include.title}}:</b> {{include.content}}
+        <b>{{include.title | markdownify | remove: "<p>" | remove: "</p>"}}:</b> {{include.content | markdownify | remove: "<p>" | remove: "</p>"}}
     </p>
 </div>

--- a/_includes/warning
+++ b/_includes/warning
@@ -1,6 +1,6 @@
 <div class="warning-popup">
     <p>
         <i class="fa fa-exclamation-circle"></i>
-        <b>{{include.title}}:</b> {{include.content}}
+        <b>{{include.title | markdownify}}:</b> {{include.content | markdownify}}
     </p>
 </div>

--- a/_includes/warning
+++ b/_includes/warning
@@ -1,12 +1,12 @@
-{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
-{% comment %}the whole include's output and markdownify it.{% endcomment %}
-{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
-{% capture includeresult %}
+{% comment %}
+We want to markdownify the title/content, however the markdownify filter does not offer an "inline" mode
+(see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
+{% endcomment %}
+{% assign include.title = include.title | markdownify | remove: "<p>" | remove: "</p>" %}
+{% assign include.content = include.content | markdownify | remove: "<p>" | remove: "</p>" %}
 <div class="warning-popup">
     <p>
         <i class="fa fa-exclamation-circle"></i>
         <b>{{include.title}}:</b> {{include.content}}
     </p>
 </div>
-{% endcapture %}
-{{ includeresult | markdownify }}

--- a/_includes/warning
+++ b/_includes/warning
@@ -2,11 +2,9 @@
 We want to markdownify the title/content, however the markdownify filter does not offer an "inline" mode
 (see https://github.com/jekyll/jekyll/issues/3571).  To get around this, we'll remove <p> </p>.
 {% endcomment %}
-{% assign include.title = include.title | markdownify | remove: "<p>" | remove: "</p>" %}
-{% assign include.content = include.content | markdownify | remove: "<p>" | remove: "</p>" %}
 <div class="warning-popup">
     <p>
         <i class="fa fa-exclamation-circle"></i>
-        <b>{{include.title}}:</b> {{include.content}}
+        <b>{{include.title | markdownify | remove: "<p>" | remove: "</p>"}}:</b> {{include.content | markdownify | remove: "<p>" | remove: "</p>"}}
     </p>
 </div>

--- a/_includes/warning
+++ b/_includes/warning
@@ -1,6 +1,12 @@
+{% comment %} In order to properly render markdown in variables, we need to capture{% endcomment %}
+{% comment %}the whole include's output and markdownify it.{% endcomment %}
+{% comment %}This is because markdownifying variables alone will wrap thine in <p> elements.{% endcomment %}
+{% capture includeresult %}
 <div class="warning-popup">
     <p>
         <i class="fa fa-exclamation-circle"></i>
-        <b>{{include.title | markdownify | strip}}:</b> {{include.content | markdownify | strip}}
+        <b>{{include.title}}:</b> {{include.content}}
     </p>
 </div>
+{% endcapture %}
+{{ includeresult | markdownify }}

--- a/_includes/warning
+++ b/_includes/warning
@@ -1,6 +1,6 @@
 <div class="warning-popup">
     <p>
         <i class="fa fa-exclamation-circle"></i>
-        <b>{{include.title | markdownify}}:</b> {{include.content | markdownify}}
+        <b>{{include.title | markdownify | strip}}:</b> {{include.content | markdownify | strip}}
     </p>
 </div>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -93,7 +93,7 @@ figure {
 }
 
 figure > img {
-  margin-bottom 1em;
+  margin-bottom: 1em;
 }
 
 figcaption {

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -89,11 +89,7 @@ code {
 }
 
 figure {
-  margin: 0;
-}
-
-figure > img {
-  margin-bottom: 1em;
+  margin: 0 0 1em 0;
 }
 
 figcaption {

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -92,6 +92,10 @@ figure {
   margin: 0;
 }
 
+figure > img {
+  margin-bottom 1em;
+}
+
 figcaption {
   text-align: center;
   margin-top: 0.5em;


### PR DESCRIPTION
Add a bottom margin to figures to give them appropriate breathing room.
Use call to `markdownify` filter to render markdown in info, warning and figure includes.