### PR TITLE
SG-12171 Use pagenames instead of permalinks for TOC

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,7 +21,7 @@
             {% assign has_children = "" %}
 
             {% for page_iter in site.pages %}
-                {% if page_iter.permalink == toc_level_2.page and page_iter.permalink == page.permalink %}
+                {% if page_iter.pagename == toc_level_2.page and page_iter.permalink == page.permalink %}
                     {% assign expand_level_2 = true %}
                 {% endif %}
             {% endfor %}
@@ -36,7 +36,7 @@
             {% for toc_level_3 in toc_level_2.children %}
                 {% assign has_children = has_children | append: "," | append: toc_level_2.page %}
                 {% for page_iter in site.pages %}
-                    {% if page_iter.permalink == toc_level_3.page and page_iter.permalink == page.permalink %}
+                    {% if page_iter.pagename == toc_level_3.page and page_iter.permalink == page.permalink %}
                         {% assign expand_level_2 = true %}
                         {% assign expand_level_3 = toc_level_3.page %}
                     {% endif %}
@@ -44,7 +44,7 @@
                 {% for toc_level_4 in toc_level_3.children %}
                     {% assign has_children = has_children | append: "," | append: toc_level_3.page %}
                     {% for page_iter in site.pages %}
-                        {% if page_iter.permalink == toc_level_4.page and page_iter.permalink == page.permalink %}
+                        {% if page_iter.pagename == toc_level_4.page and page_iter.permalink == page.permalink %}
                             {% assign expand_level_2 = true %}
                             {% assign expand_level_3 = toc_level_3.page %}
                         {% endif %}

--- a/_includes/nav_entry.html
+++ b/_includes/nav_entry.html
@@ -19,7 +19,7 @@
                     class="nav-entry"
                 {% endif %}
 
-                href="{{ page_iter.url | absolute_url }}"
+                href="{{ page_iter.url | absolute_url }}?title={{ page_iter.title | url_encode }}"
             >
                 {{include.indent}}{{ page_iter.title }}
             </a>

--- a/_includes/nav_entry.html
+++ b/_includes/nav_entry.html
@@ -2,7 +2,7 @@
 {% if include.entry.page %}
 
     {% for page_iter in site.pages %}
-        {% if page_iter.permalink == include.entry.page %}
+        {% if page_iter.pagename == include.entry.page %}
 
             <div>
 


### PR DESCRIPTION
As part of the move to using UIDs for page URLs, we will switch to using pagename as a unique identifier for pages internally, including in the TOC.

Additionally, we'll append a URL-friendly version of the page title in a GET request to generated URLs in the TOC to increase URL readability.