### PR TITLE
Check for external links using site.baseurl

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -107,12 +107,8 @@
     (function() {
       var links = document.links;
       for (var i = 0, linksLength = links.length; i < linksLength; i++) {
-        // temp fix: make sure sphinx repos on developer site appear as external links from dev site.
-        if (links[i].pathname.startsWith('/tk-doc-generator')) {
-            // no external links for the doc generator - but for all other developer site /tk-links
-            continue;
-        }
-        if (links[i].hostname != window.location.hostname || links[i].pathname.startsWith('/tk-') || links[i].pathname.startsWith('/sg-') || links[i].pathname.startsWith('/python-api') || links[i].pathname.startsWith('/rest-api') ) {
+        // Make non-local paths appear as external links.
+        if (! links[i].pathname.startsWith('{{ site.baseurl }}')) {
           links[i].target = '_blank';
           links[i].className += ' external-link-decoration';
         }


### PR DESCRIPTION
While building docs for [`tk-katana`](https://wwfxuk.github.io/tk-katana), the previous logic was making all links in TOC open in a new tab.

This was from the `links[i].pathname.startsWith('/tk-')` condition, which makes me wonder whether `tk-doc-generator` was intended to be used at all for generating `tk-*` apps/engine/framework documentations.