### PR TITLE
Fixed landing page to use page names

### DIFF
--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -13,19 +13,25 @@ layout: default
     </div>
 
     <div style="display: flex; flex-wrap: wrap; margin-top: 10px; justify-content: center;" >
-    {% for tile in site.data.landing_page.tiles%}
+    {% for tile in site.data.landing_page.tiles -%}
 
         <div
             style="cursor: pointer; width: 190px; margin: 5px; padding: 5px; padding-top: 10px; padding-bottom: 10px; border: 1px solid #0696D7; border-radius: 4px; text-align: center;"
             onmouseover="this.style.background='#eeeeee';"
             onmouseout="this.style.background='white';"
-            onclick="location.href='{{ tile.target }}';"
+            onclick="location.href=
+                {%- for page_iter in site.pages -%}
+                    {%- if page_iter.pagename == tile.page -%}
+                        '{{ page_iter.url | absolute_url }}?title={{ page_iter.title | url_encode }}'
+                    {%- endif -%}
+                {%- endfor -%}
+            ;"
         >
             <img style="width: 80px; height: 80px; box-shadow: none;" src="{{ tile.image }}"/>
             <div class="fs-2">{{ site.data.landing_page_text[tile.name] }}</div>
         </div>
 
-    {% endfor %}
+    {%- endfor %}
     </div>
 
 


### PR DESCRIPTION
:warning: Will probably break existing YAMLs using `target:` :warning: 

Changed to fetch URL based off page name (using similar code found in `nav_entry.html`)

This PR partly fixes the issue in [tk-doc-generator](https://developer.shotgunsoftware.com/tk-doc-generator/) landing page where clicking on the tiles will go to invalid pages.

The 'target: ./some-page' in the `landing_page.yml` do not point ot UID URLs, hence 
https://github.com/shotgunsoftware/developer.shotgunsoftware.com/pull/80

I replaced `target:` with `page:` to make the syntax more similar to `toc.yml`, but this will break any existing links (if it is not broken already)