### PR TITLE
Adds pre/post body custom content injection

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,8 +57,12 @@
       <div class="main-content">
 
         <div class="page-content">
+
+            {{ site.custom_pre_content }}  
+
             {{ content }}
 
+            {{ site.custom_post_content }}  
 
             {% for toc_level_1 in site.data.toc %}
                 {% for toc_level_2 in toc_level_1.children %}


### PR DESCRIPTION
Adds two configuration parameters, `custom_pre_content` and `custom_post_content`, which can be used to inject html before and after the content. 

For example if a search indexing service requires the content to be wrapped with a special tag, these config options can be used to achieve custom html divs or metadata before and after the content.