### PR TITLE
Support for google custom search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,11 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 # Enable or disable the site search
 search_enabled: true
 
+# add a google custom search box
+# (see https://developers.google.com/custom-search/docs/element)
+# enter a search engine id in order to enable this
+google_custom_search_id: null
+
 # Aux links for the upper right navigation
 aux_links:
   "Just the Docs on GitHub":

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,9 @@
   <script type="text/javascript" src="{{ "/assets/js/just-the-docs.js" | absolute_url }}"></script>
   <script type="text/javascript" src="{{ "/assets/js/vendor/anchor.min.js" | absolute_url }}"></script>
 
-
+  {% if site.google_custom_search_id != nil %}
+  <script async src="https://cse.google.com/cse.js?cx={{ site.google_custom_search_id }}"></script>
+  {% endif %}
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,8 +10,13 @@
 
     <div class="side-bar">
       <a href="{% if site.baseurl == "" or site.baseurl == nil %}/{% else %}{{site.baseurl}}{% endif %}" class="site-title fs-6 lh-tight">{{ site.title }}</a>
-      <span class="fs-3"><button class="js-main-nav-trigger navigation-list-toggle btn btn-outline" type="button" data-text-toggle="Hide">Menu</button></span>
+      <span class="fs-3"><button class="js-main-nav-trigger navigation-list-toggle btn btn-outline" type="button" data-text-toggle="Hide">Menu</button></span>    
       <div class="navigation main-nav js-main-nav">
+
+        {% if site.google_custom_search_id != nil %}
+          <div class="gcse-search"></div>
+        {% endif %}
+    
         {% include nav.html %}
       </div>
       <footer role="contentinfo" class="site-footer">
@@ -35,7 +40,7 @@
 
     <div class="main-content-wrap">
       <div class="page-header">
-        <div class="main-content">
+        <div class="main-content">        
           {% if site.search_enabled != nil %}
           <div class="search js-search">
             <div class="search-input-wrap">

--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -12,10 +12,6 @@ layout: default
     {{ site.data.landing_page_text.title }}
     </div>
 
-    {% if site.google_custom_search_id != nil %}
-        <div class="gcse-search"></div>
-    {% endif %}
-
     <div style="display: flex; flex-wrap: wrap; margin-top: 10px; justify-content: center;" >
     {% for tile in site.data.landing_page.tiles%}
 

--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -12,6 +12,10 @@ layout: default
     {{ site.data.landing_page_text.title }}
     </div>
 
+    {% if site.google_custom_search_id != nil %}
+        <div class="gcse-search"></div>
+    {% endif %}
+
     <div style="display: flex; flex-wrap: wrap; margin-top: 10px; justify-content: center;" >
     {% for tile in site.data.landing_page.tiles%}
 

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -112,3 +112,42 @@
     background-color: darken($body-background-color, 2%);
   }
 }
+
+// google search styling
+
+// style reset for all children
+.gsc-control-cse * {
+  border: unset;
+  padding: unset;
+  margin: unset;
+  min-width: unset;
+  box-shadow: unset;
+  background-color: unset;
+}
+
+// override some values from the built-in gcse style
+.gsc-control-cse {
+  padding: 0px !important;
+  border: 0px !important;
+}
+
+.gsc-input {
+  padding: 0px !important;
+}
+
+.gsc-input-box {
+  border-radius: 3px;
+  border: none !important;
+}
+
+form.gsc-search-box {
+  margin: 0px !important;
+}
+
+input.gsc-input {
+  font-size: 12px !important;
+}
+
+.gsc-search-button {
+  padding: 6px !important; 
+}


### PR DESCRIPTION
This adds support to google custom search in the theme:

![search](https://user-images.githubusercontent.com/337710/64493815-e9b14f80-d27c-11e9-8fd4-2ca9bcbb1875.gif)

This adds support for a parameter `google_custom_search_id` which when specified in the configuration, turns on a search element in the sidebar.
